### PR TITLE
Make available this crate in stable and beta channel of Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 rust:
+  - stable
+  - beta
   - nightly
 script:
   - cargo build --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,6 @@
 //! }
 //! ```
 
-#![feature(io)]
-
 extern crate term;
 extern crate libc;
 extern crate signal_notify;


### PR DESCRIPTION
termfest uses `std::io::Read::chars` method to parse terminal events, but it's still unstable feature.

In this PR, decoding a character from bytes is implemented in this repository and termfest no longer require  snightly rust.