### PR TITLE
screen.clear() now resets cell attributes to default

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -116,6 +116,7 @@ impl Screen {
     pub fn clear(&mut self) {
         for cell in self.cells.iter_mut() {
             cell.ch = ' ';
+            cell.attribute = Attribute::default();
         }
     }
 


### PR DESCRIPTION
I noticed `screen.clear()` is only clearing cell contents without clearing their attributes. If some cells have a non-default bg color, the bg color of those cells doesn't get cleared and remains on the screen after clearing.

In the docs, you described the expected behavior as:

> clear the internal buffer states. If clear and flush is called, the terminal will be cleared **(nothing will be rendered)**.

Therefore, I think it should also clear the attributes as well. This commit fixes the issue.